### PR TITLE
Fix build with Java 9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ tmp/i18n:
 compile: tmp/stamp/compile
 tmp/stamp/compile: $(SOURCES_DIST)
 	@/bin/echo -e "$(JAVAC_CMD)\ttmp/classes/*.class"
-	$(JAVAC) -d tmp/classes -classpath tmp/classes:$(CLASSPATH) -sourcepath src/ $^
+	$(JAVAC) -source 1.7 -d tmp/classes -classpath tmp/classes:$(CLASSPATH) -sourcepath src/ $^
 	touch $@
 
 translation: tmp/i18n/gnome-split.pot $(TRANSLATIONS)

--- a/configure
+++ b/configure
@@ -307,6 +307,9 @@ sub check_runtime(\$$$$) {
 		chomp $version[$i];
 
 		if (!($version[$i] =~ /^\d+$/)) {
+			if ($i > 0 && $version[0] >= 9) {
+				last;
+			}
 			output "can't parse version\n";
 			$$scalarref = "";
 			return


### PR DESCRIPTION
Java 9 will be out in 28 days, and `gnome-split` currently fails to compile with it. All of the problems can be fixed in the build system.

Instead of the first commit, maybe just dropping all the code to check for versions is a good idea. None of those older JVMs exist anymore.